### PR TITLE
Add the mconnect shell extension

### DIFF
--- a/gnome-shell-extension-mconnect-git/PKGBUILD
+++ b/gnome-shell-extension-mconnect-git/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Rich Daley <rich at fishpercolator dot co dot uk>
+# template input; name=github
+pkgname=gnome-shell-extension-mconnect-git
+pkgver=r257.49a861f
+pkgrel=1
+pkgdesc="KDE Connect/MConnect integration for Gnome Shell"
+arch=('any')
+url="https://github.com/andyholmes/gnome-shell-extension-mconnect"
+license=('GPL2')
+depends=('gnome-shell')
+optdepends=('mconnect' 'kdeconnect')
+makedepends=('git' 'meson' 'findutils') 
+install=gschemas.install
+source=("${pkgname}::git+${url}.git")
+noextract=()
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/$pkgname"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+	cd "$srcdir/$pkgname"
+	if [ -d build ]; then
+	  rm -r build
+	fi
+}
+
+build() {
+	cd "$srcdir/$pkgname"
+	meson build --prefix=$pkgdir/usr
+}
+
+package() {
+	cd "$srcdir/$pkgname"
+	ninja -C build install
+	find $pkgdir -name schemas -type d -exec glib-compile-schemas {} \;
+}
+

--- a/gnome-shell-extension-mconnect-git/gschemas.install
+++ b/gnome-shell-extension-mconnect-git/gschemas.install
@@ -1,0 +1,1 @@
+../gschemas.install


### PR DESCRIPTION
This PKGBUILD adds support for the mconnect extension which provides a GNOME interface to KDE Connect / MConnect.

I decided not to use it after all but it built and ran just fine so I thought I'd contribute it in case you wanted to add it to the list. I haven't submitted it to AUR yet but I will if you are happy to accept it into your repo.