### PR TITLE
Updated the github URL for caffeine following change in maintainer

### DIFF
--- a/gnome-shell-extension-caffeine-git/PKGBUILD
+++ b/gnome-shell-extension-caffeine-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=r130
 pkgrel=1
 pkgdesc="Fill the cup to inhibit auto suspend and screensaver."
 arch=(any)
-url="https://github.com/eonpatapon/gnome-shell-extension-caffeine"
+url="https://github.com/qunxyz/gnome-shell-extension-caffeine"
 license=(GPLv2)
 
 # template input; name=git
@@ -17,7 +17,7 @@ license=(GPLv2)
 
 build() {
   cd "$_gitname"
-  ./update-locale.sh
+  ./build.sh
 }
 
 package_09_icons() {


### PR DESCRIPTION
eonpatapon has stopped maintaining the project. Qunxyz has become
temporary maintainer and has made many changes already.